### PR TITLE
add missing comma to settings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ Settings
     "uf_translate_tabs_to_spaces": true,
     "uf_case": "upper", // "upper" or "lower" or "capitalize" or "nochange"
     "uf_reserved_case": "upper", // "upper" or "lower" or "capitalize" or "nochange"
-    "uf_reserved_words":"SELECT, FROM, WHERE, CREATE" // Put commas to separate reserved words
+    "uf_reserved_words":"SELECT, FROM, WHERE, CREATE", // Put commas to separate reserved words
     "uf_comment_syntax": "uroboroSQL", // "uroboroSQL" or "doma2"
     "uf_escapesequence_u005c": false,
     "uf_save_on_format": true,


### PR DESCRIPTION
- Sublime gives error when you directly copy settings from here to sublime. This fixes the issue.